### PR TITLE
Allow for primary keys with different names from the database columns.

### DIFF
--- a/gino/crud.py
+++ b/gino/crud.py
@@ -571,7 +571,8 @@ class CRUDModel(Model):
         """
         exps = []
         for c in self.__table__.primary_key.columns:
-            exps.append(c == getattr(self, self._column_name_map.invert_get(c.name)))
+            exps.append(c == getattr(self,
+                                     self._column_name_map.invert_get(c.name)))
         if exps:
             return sa.and_(*exps)
         else:

--- a/gino/crud.py
+++ b/gino/crud.py
@@ -525,7 +525,7 @@ class CRUDModel(Model):
             try:
                 val = ident_[i]
             except KeyError:
-                val = ident_[c.name]
+                val = ident_[cls._column_name_map.invert_get(c.name)]
             clause = clause.where(c == val)
         if timeout is not DEFAULT:
             clause = clause.execution_options(timeout=timeout)
@@ -571,7 +571,7 @@ class CRUDModel(Model):
         """
         exps = []
         for c in self.__table__.primary_key.columns:
-            exps.append(c == getattr(self, c.name))
+            exps.append(c == getattr(self, self._column_name_map.invert_get(c.name)))
         if exps:
             return sa.and_(*exps)
         else:

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -282,3 +282,37 @@ async def test_lookup_287(bind):
         assert await Game.select('channel_id').gino.all() == [('X',), ('Z',)]
     finally:
         await Game.gino.drop()
+
+
+async def test_lookup_custom_name(bind):
+    from gino.exceptions import NoSuchRowError
+
+    class ModelWithCustomColumnNames(db.Model):
+        __tablename__ = 'gino_test_custom_column_names'
+
+        id = db.Column('other', db.Integer(), primary_key=True)
+        field = db.Column(db.Text())
+
+    await ModelWithCustomColumnNames.gino.create()
+
+    try:
+        # create
+        m1 = await ModelWithCustomColumnNames.create(id=1, field='A')
+        m2 = await ModelWithCustomColumnNames.create(id=2, field='B')
+
+        # update
+        uq = m1.update(field='C')
+        await uq.apply()
+
+        # lookup
+        assert set(tuple(x) for x in await ModelWithCustomColumnNames.select('id').gino.all()) == {(1,), (2,)}
+        assert (await ModelWithCustomColumnNames.get(2)).field == "B"
+        assert (await ModelWithCustomColumnNames.get(1)).field == "C"
+        assert await ModelWithCustomColumnNames.get(3) is None
+
+        # delete
+        assert (await ModelWithCustomColumnNames.delete.where(ModelWithCustomColumnNames.id == 3).gino.status())[0][-1] == '0'
+        assert (await ModelWithCustomColumnNames.delete.where(ModelWithCustomColumnNames.id == 2).gino.status())[0][-1] == '1'
+        assert set(tuple(x) for x in await ModelWithCustomColumnNames.select('id').gino.all()) == {(1,)}
+    finally:
+        await ModelWithCustomColumnNames.gino.drop()


### PR DESCRIPTION
Fixes #599.

Adds the correct column lookup when the attribute name for a primary key in the model is different than the column name in the database.
