### PR TITLE
Remove setter decorator for Parent.add_child method

### DIFF
--- a/docs/how-to/loaders.rst
+++ b/docs/how-to/loaders.rst
@@ -353,7 +353,6 @@ Similarly, you can build many-to-many relationships in the same way::
         def children(self):
             return self._children
 
-        @children.setter
         def add_child(self, child):
             self._children.add(child)
             child._parents.add(self)

--- a/src/gino/loader.py
+++ b/src/gino/loader.py
@@ -1,4 +1,5 @@
 import warnings
+import types
 
 from sqlalchemy import select
 from sqlalchemy.schema import Column
@@ -117,7 +118,16 @@ class ModelLoader(Loader):
         else:
             for key, value in self.extras.items():
                 value, distinct_ = value.do_load(row, context)
-                if distinct_ is not None:
+                if distinct_ is None:
+                    continue
+
+                if (
+                    hasattr(self.model, key)
+                    and not isinstance(getattr(self.model, key), property)
+                    and isinstance(getattr(self.model, key), types.MethodType)
+                ):
+                    getattr(rv, key)(value)
+                else:
                     setattr(rv, key, value)
             return rv, distinct
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -93,6 +93,12 @@ class Team(db.Model):
         self._members.add(user)
 
 
+class TeamWithoutMembersSetter(Team):
+
+    def add_member(self, user):
+        self._members.add(user)
+
+
 class Company(db.Model):
     __tablename__ = "gino_companies"
 
@@ -109,6 +115,12 @@ class Company(db.Model):
         return self._teams
 
     @teams.setter
+    def add_team(self, team):
+        self._teams.add(team)
+
+
+class CompanyWithoutTeamsSetter(Company):
+
     def add_team(self, team):
         self._teams.add(team)
 


### PR DESCRIPTION
Method `add_child` does not behave like a `setter` for a `children` property.
Actually, `children` property is read-only.