### PR TITLE
Implement baked query

### DIFF
--- a/docs/how-to/bakery.rst
+++ b/docs/how-to/bakery.rst
@@ -1,0 +1,170 @@
+Bake Queries
+============
+
+Baked queries are used to boost execution performance for constantly-used queries.
+Similar to the :doc:`orm/extensions/baked` in SQLAlchemy, GINO could also cache the
+object’s construction and string-compilation steps. Furthermore, GINO automatically
+manages a prepared statement for each baked query in every active connection in the
+pool. Executing baked queries is at least 40% faster than running normal queries, but
+you need to bake them before creating the engine.
+
+GINO provides two approaches for baked queries:
+
+1. Low-level :class:`~gino.bakery.Bakery` API
+2. High-level :meth:`Gino.bake() <gino.api.Gino.bake>` integration
+
+
+Use Bakery with Bare Engine
+---------------------------
+
+First, we need a bakery::
+
+    import gino
+
+    bakery = gino.Bakery()
+
+Then, let's bake some queries::
+
+    db_time = bakery.bake("SELECT now()")
+
+Or queries with parameters::
+
+    user_query = bakery.bake("SELECT * FROM users WHERE id = :uid")
+
+Let's assume we have this ``users`` table defined in SQLAlchemy Core::
+
+    import sqlalchemy as sa
+
+    metadata = sa.MetaData()
+    user_table = sa.Table(
+        "users", metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String),
+    )
+
+Now we can bake a similar query with SQLAlchemy Core::
+
+    user_query = bakery.bake(
+        sa.select([user_table]).where(user.c.id == sa.bindparam("uid"))
+    )
+
+These baked queries are usually global, and supposed to be shared across the
+application. To run them, we need an engine with the bakery::
+
+    engine = await gino.create_engine("postgresql://localhost/", bakery=bakery)
+
+By doing so, GINO will bake the queries in the bakery. As new connections are added to
+the DB pool, the prepared statements are automatically created behind the scene.
+
+To execute the baked queries, you could treat the :class:`~gino.bakery.BakedQuery`
+instances as if they are the queries themselves, for example::
+
+    now = await engine.scalar(db_time)
+
+Pass in parameter values::
+
+    row = await engine.first(user_query, uid=123)
+
+
+Use the :class:`~gino.api.Gino` Integration
+--------------------------------------------
+
+In a more common scenario, there will be a :class:`~gino.api.Gino>` instance, which has
+usually a ``bind`` set - either explicitly or by the Web framework extensions::
+
+    from gino import Gino
+
+    db = Gino()
+
+    async def main():
+        async with db.with_bind("postgresql://localhost/"):
+            ...
+
+A :class:`~gino.bakery.Bakery` is automatically created in the ``db`` instance, and fed
+to the engine implicitly. You can immediately start to bake queries without further
+ado::
+
+    class User(db.Model):
+        __tablename__ = "users"
+
+        id = db.Column(db.Integer, primary_key=True)
+        name = db.Column(sa.String)
+
+    db_time = db.bake("SELECT now()")
+    user_getter = db.bake(User.query.where(User.id == db.bindparam("uid")))
+
+And the execution is also simplified with the same ``bind`` magic::
+
+    async def main():
+        async with db.with_bind("postgresql://localhost/"):
+            print(await db_time.scalar())
+
+            user: User = await user_getter.first(uid=1)
+            print(user.name)
+
+
+How to customize loaders?
+-------------------------
+
+If possible, you could bake the additional execution options into the query::
+
+    user_getter = db.bake(
+        User.query.where(User.id == db.bindparam("uid")).execution_options(
+            loader=User.load(comment="Added by loader.")
+        )
+    )
+
+The :meth:`~gino.bakery.Bakery.bake` method accepts keyword arguments as execution
+options to e.g. simplify the example above into::
+
+    user_getter = db.bake(
+        User.query.where(User.id == db.bindparam("uid")),
+        loader=User.load(comment="Added by loader."),
+    )
+
+If the query construction is complex, :meth:`~gino.bakery.Bakery.bake` could also be
+used as a decorator::
+
+    @db.bake
+    def user_getter():
+        return User.query.where(User.id == db.bindparam("uid")).execution_options(
+            loader=User.load(comment="Added by loader.")
+        )
+
+Or with short execution options::
+
+    @db.bake(loader=User.load(comment="Added by loader."))
+    def user_getter():
+        return User.query.where(User.id == db.bindparam("uid"))
+
+Meanwhile, it is also possible to override the loader at runtime::
+
+    user: User = await user_getter.load(User).first(uid=1)
+    print(user.name)  # no more comment on user!
+
+.. hint::
+
+    This override won't affect the baked query - it's used only in this execution.
+
+
+What APIs are available on :class:`~gino.bakery.BakedQuery`?
+------------------------------------------------------------
+
+:class:`~gino.bakery.BakedQuery` is a :class:`~gino.api.GinoExecutor`, so it inherited
+all the APIs like :meth:`~gino.api.GinoExecutor.all`,
+:meth:`~gino.api.GinoExecutor.first`, :meth:`~gino.api.GinoExecutor.one`,
+:meth:`~gino.api.GinoExecutor.one_or_none`, :meth:`~gino.api.GinoExecutor.scalar`,
+:meth:`~gino.api.GinoExecutor.status`, :meth:`~gino.api.GinoExecutor.load`,
+:meth:`~gino.api.GinoExecutor.timeout`, etc.
+
+:class:`~gino.api.GinoExecutor` is actually the chained ``.gino`` helper API seen
+usually in queries like this::
+
+    user = await User.query.where(User.id == 123).gino.first()
+
+So a :class:`~gino.bakery.BakedQuery` can be seen as a normal query with the ``.gino``
+suffix, plus it is directly executable.
+
+.. seealso::
+
+    Please see API document of :mod:`gino.bakery` for more information.

--- a/docs/theme/static/css/gino.css
+++ b/docs/theme/static/css/gino.css
@@ -27,6 +27,10 @@ code, kbd, samp {
     border-radius: 2px;
 }
 
+strong {
+    font-weight: 700;
+}
+
 :root {
     --v-primary-base: #212B73;
     --v-secondary-base: #AD755C;

--- a/src/gino/__init__.py
+++ b/src/gino/__init__.py
@@ -1,4 +1,5 @@
 from .api import Gino  # NOQA
+from .bakery import Bakery
 from .engine import GinoEngine, GinoConnection  # NOQA
 from .exceptions import *  # NOQA
 from .strategies import GinoStrategy  # NOQA

--- a/src/gino/__init__.py
+++ b/src/gino/__init__.py
@@ -6,7 +6,12 @@ from .strategies import GinoStrategy  # NOQA
 
 
 def create_engine(*args, **kwargs):
-    """Shortcut for :func:`sqlalchemy.create_engine` with ``strategy="gino"``."""
+    """
+    Shortcut for :func:`sqlalchemy.create_engine` with ``strategy="gino"``.
+
+    .. versionchanged:: 1.1
+       Added the ``bakery`` keyword argument, please see :class:`~.bakery.Bakery`.
+    """
 
     from sqlalchemy import create_engine
 

--- a/src/gino/api.py
+++ b/src/gino/api.py
@@ -5,11 +5,11 @@ from sqlalchemy.engine.url import make_url, URL
 from sqlalchemy.sql.base import Executable
 from sqlalchemy.sql.schema import SchemaItem
 
+from . import json_support
 from .crud import CRUDModel
 from .declarative import declarative_base, declared_attr
 from .exceptions import UninitializedError
 from .schema import GinoSchemaVisitor, patch_schema
-from . import json_support
 
 
 class GinoExecutor:
@@ -75,8 +75,7 @@ class GinoExecutor:
         """
         if model is not None:
             model = weakref.ref(model)
-        self._query = self._query.execution_options(model=model)
-        return self
+        return self.execution_options(model=model)
 
     def return_model(self, switch):
         """
@@ -86,8 +85,7 @@ class GinoExecutor:
         information.
 
         """
-        self._query = self._query.execution_options(return_model=switch)
-        return self
+        return self.execution_options(return_model=switch)
 
     def timeout(self, timeout):
         """
@@ -97,8 +95,7 @@ class GinoExecutor:
         information.
 
         """
-        self._query = self._query.execution_options(timeout=timeout)
-        return self
+        return self.execution_options(timeout=timeout)
 
     def load(self, value):
         """
@@ -113,7 +110,18 @@ class GinoExecutor:
         information.
 
         """
-        self._query = self._query.execution_options(loader=value)
+        return self.execution_options(loader=value)
+
+    def execution_options(self, **options):
+        """
+        Set execution options to this query in a chaining call.
+
+        Read :meth:`~gino.engine.GinoConnection.execution_options` for more
+        information.
+
+        :param options: Multiple execution options.
+        """
+        self._query = self._query.execution_options(**options)
         return self
 
     async def all(self, *multiparams, **params):
@@ -185,10 +193,7 @@ class GinoExecutor:
         (:class:`Gino`) is bound, while metadata is found in this query.
 
         """
-        connection = self._query.bind.current_connection
-        if connection is None:
-            raise ValueError("No Connection in context, please provide one")
-        return connection.iterate(self._query, *multiparams, **params)
+        return self._query.bind.iterate(self._query, *multiparams, **params)
 
 
 class _BindContext:
@@ -354,6 +359,9 @@ class Gino(sa.MetaData):
         self._model = declarative_base(self, model_classes)
         self.declared_attr = declared_attr
         self.quoted_name = sa.sql.quoted_name
+        from .bakery import Bakery
+
+        self._bakery = Bakery()
         for mod in json_support, sa:
             for key in mod.__all__:
                 if not hasattr(self, key) and key not in self.no_delegate:
@@ -414,7 +422,7 @@ class Gino(sa.MetaData):
         if isinstance(bind, URL):
             from . import create_engine
 
-            bind = await create_engine(bind, loop=loop, **kwargs)
+            bind = await create_engine(bind, loop=loop, bakery=self._bakery, **kwargs)
         self.bind = bind
         return bind
 
@@ -429,6 +437,9 @@ class Gino(sa.MetaData):
         :return: :class:`~.engine.GinoEngine` or ``None`` if self is not bound.
 
         """
+        from .bakery import Bakery
+
+        self._bakery = Bakery()
         bind, self.bind = self.bind, None
         return bind
 
@@ -531,6 +542,13 @@ class Gino(sa.MetaData):
         """
         return self.bind.transaction(*args, **kwargs)
 
+    def bake(self, func_or_elem=None, **execution_options):
+        return self._bakery.bake(func_or_elem, metadata=self, **execution_options)
+
+    @property
+    def bakery(self):
+        return self._bakery
+
 
 class _PlaceHolder:
     __slots__ = "_exception"
@@ -547,3 +565,6 @@ class _PlaceHolder:
         if key == "_exception":
             return super().__setattr__(key, value)
         raise self._exception
+
+    def __bool__(self):
+        return False

--- a/src/gino/api.py
+++ b/src/gino/api.py
@@ -120,6 +120,8 @@ class GinoExecutor:
         information.
 
         :param options: Multiple execution options.
+
+        .. versionadded:: 1.1
         """
         self._query = self._query.execution_options(**options)
         return self
@@ -543,10 +545,20 @@ class Gino(sa.MetaData):
         return self.bind.transaction(*args, **kwargs)
 
     def bake(self, func_or_elem=None, **execution_options):
+        """
+        A delegate of :meth:`Bakery.bake() <.bakery.Bakery.bake>`.
+
+        .. versionadded:: 1.1
+        """
         return self._bakery.bake(func_or_elem, metadata=self, **execution_options)
 
     @property
     def bakery(self):
+        """
+        The bundled :class:`~.bakery.Bakery` instance.
+
+        .. versionadded:: 1.1
+        """
         return self._bakery
 
 

--- a/src/gino/bakery.py
+++ b/src/gino/bakery.py
@@ -1,0 +1,164 @@
+import copy
+
+from sqlalchemy import text
+
+from .api import GinoExecutor, _PlaceHolder
+from .exceptions import UninitializedError, InitializedError
+
+
+class BakedQuery(GinoExecutor):
+    """Represents a pre-compiled and possibly prepared query for faster execution.
+
+    :class:`BakedQuery` is created by :meth:`Bakery.bake`, and can be executed by
+    :class:`~gino.engine.GinoEngine` or :class:`~gino.engine.GinoConnection`. If there
+    is a proper bind in the baked query, contextual execution APIs inherited from
+    :class:`~.api.GinoExecutor` can also be used.
+    """
+
+    def __init__(self, elem, metadata, hash_=None):
+        super().__init__(self)
+        self._elem = elem
+        self._metadata = metadata
+        if hash_ is None:
+            self._hash = hash(elem)
+        else:
+            self._hash = hash_
+        self._compiled_sql = None
+        self._sql = None
+
+    def _set_sql(self, sql):
+        self._sql = sql
+
+    def _execute_on_connection(self, conn, multiparams, params):
+        return conn._execute_baked_query(self, multiparams, params)
+
+    def get(self, _):
+        """Internal API to get the :attr:`compiled_sql`.
+
+        :param _: Ignored.
+        """
+        return self.compiled_sql
+
+    def __setitem__(self, key, value):
+        self._compiled_sql = value
+
+    @property
+    def compiled_sql(self):
+        """Internal API to get the SQLAlchemy compiled sql context."""
+        return self._compiled_sql
+
+    @property
+    def sql(self):
+        """Internal API to get the compiled raw SQL."""
+        return self._sql
+
+    @property
+    def query(self):
+        """Internal API to get the query instance before compilation."""
+        return self._elem
+
+    @property
+    def bind(self):
+        """Internal API to provide a proper bind if found."""
+        rv = self._elem.bind
+        if rv is not None:
+            return rv
+        if self._metadata is None:
+            return _PlaceHolder(UninitializedError("Gino engine is not initialized."))
+        return self._metadata.bind
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return self._hash == getattr(other, "_hash", None)
+
+    def execution_options(self, **kwargs):
+        """
+        Set execution options on a shadow query of this baked query.
+
+        The execution options set in this method won't affect the execution options in
+        the baked query.
+
+        Read :meth:`~gino.engine.GinoConnection.execution_options` for more
+        information.
+
+        :param options: Multiple execution options.
+        :return: A shadow of the baked query with new execution options but still
+                 functions as a baked query.
+        """
+        rv = _ShadowBakedQuery(self)
+        return rv.execution_options(**kwargs)
+
+
+class _ShadowBakedQuery(BakedQuery):
+    def __init__(self, bq):
+        super().__init__(bq.query, bq._metadata, hash(bq))
+        self._compiled_sql = copy.copy(bq.compiled_sql)
+        self._sql = bq._sql
+
+    def execution_options(self, **kwargs):
+        self._elem = self._elem.execution_options(**kwargs)
+        self._compiled_sql.execution_options = self._elem.get_execution_options()
+        return self
+
+
+class Bakery:
+    """Factory and warehouse of baked queries.
+
+    You may provide a bakery to a :class:`~gino.engine.GinoEngine` during creation as
+    the ``bakery`` keyword argument, and the engine will bake the queries and create
+    corresponding prepared statements for each of the connections in the pool.
+
+    A :class:`~gino.api.Gino` instance has a built-in :attr:`~gino.api.Gino.bakery`,
+    it's automatically given to the engine during :meth:`~gino.api.Gino.set_bind` or
+    :meth:`~gino.api.Gino.with_bind`.
+    """
+
+    query_cls = BakedQuery
+
+    def __init__(self):
+        self._queries = []
+        self._closed = False
+
+    def __iter__(self):
+        return iter(self._queries)
+
+    def bake(self, func_or_elem=None, **execution_options):
+        """Bake a query.
+
+        You can bake raw SQL strings or SQLAlchemy Core query instances. This method
+        adds the given query into a queue in the bakery, and bakes it only when the
+        bakery is set to an :class:`~gino.engine.GinoEngine` from which the bakery could
+        learn about the SQL dialect and compile the queries into SQL. Once done, the
+        bakery is "closed", you can neither give it to another engine, nor use it to
+        bake more queries.
+
+        :param func_or_elem: A :class:`str` or a SQLAlchemy Core query instance, or a
+                             function that returns such results.
+        :param execution_options: Shortcut to add SQLAlchemy execution options to the
+                                  query.
+        :return: A :class:`BakedQuery` instance.
+        """
+        if self._closed:
+            raise InitializedError(
+                "The bakery is closed. Please bake before feeding this bakery to a "
+                "engine constructor."
+            )
+
+        if func_or_elem is None:
+
+            def _wrapper(val):
+                return self.bake(val, **execution_options)
+
+            return _wrapper
+
+        metadata = execution_options.pop("metadata", None)
+        elem = func_or_elem() if callable(func_or_elem) else func_or_elem
+        if isinstance(elem, str):
+            elem = text(elem)
+        if execution_options:
+            elem = elem.execution_options(**execution_options)
+        bq = self.query_cls(elem, metadata)
+        self._queries.append(bq)
+        return bq

--- a/src/gino/declarative.py
+++ b/src/gino/declarative.py
@@ -112,10 +112,15 @@ class ModelType(type):
         rv.__namespace__ = namespace
         if rv.__table__ is None:
             rv.__table__ = getattr(rv, "_init_table")(rv)
+
+        for each_cls in rv.__mro__[::-1]:
+            for k, v in getattr(each_cls, "__namespace__", each_cls.__dict__).items():
+                if callable(v) and getattr(v, "__declared_attr_with_table__", False):
+                    setattr(rv, k, v(rv))
         return rv
 
 
-def declared_attr(m):
+def declared_attr(m=None, *, with_table=False):
     """
     Mark a class-level method as a factory of attribute.
 
@@ -156,8 +161,33 @@ def declared_attr(m):
 
         This doesn't work if the model already had a ``__table__``.
 
+    .. versionchanged:: 1.1
+
+        Added ``with_table`` parameter which works after the ``__table__`` is created::
+
+        class User(db.Model):
+            __tablename__ = "users"
+
+            ...
+
+            @db.declared_attr(with_table=True)
+            def table_name(cls):
+                # this is called only once when defining the class
+                return cls.__table__.name
+
+        assert User.table_name == "users"
+
     """
-    m.__declared_attr__ = True
+    if m is None:
+
+        def _wrapper(m_):
+            return declared_attr(m_, with_table=with_table)
+
+        return _wrapper
+    if with_table:
+        m.__declared_attr_with_table__ = True
+    else:
+        m.__declared_attr__ = True
     return m
 
 

--- a/src/gino/dialects/asyncpg.py
+++ b/src/gino/dialects/asyncpg.py
@@ -145,8 +145,7 @@ class DBAPICursor(base.DBAPICursor):
         self._attributes = None
         self._status = None
 
-    async def prepare(self, context, clause=None):
-        timeout = context.timeout
+    async def _acquire(self, timeout):
         if timeout is None:
             conn = await self._conn.acquire(timeout=timeout)
         else:
@@ -154,6 +153,10 @@ class DBAPICursor(base.DBAPICursor):
             conn = await self._conn.acquire(timeout=timeout)
             after = time.monotonic()
             timeout -= after - before
+        return conn, timeout
+
+    async def prepare(self, context, clause=None):
+        conn, timeout = await self._acquire(context.timeout)
         prepared = await conn.prepare(context.statement, timeout=timeout)
         try:
             self._attributes = prepared.get_attributes()
@@ -164,13 +167,7 @@ class DBAPICursor(base.DBAPICursor):
         return rv
 
     async def async_execute(self, query, timeout, args, limit=0, many=False):
-        if timeout is None:
-            conn = await self._conn.acquire(timeout=timeout)
-        else:
-            before = time.monotonic()
-            conn = await self._conn.acquire(timeout=timeout)
-            after = time.monotonic()
-            timeout -= after - before
+        conn, timeout = await self._acquire(timeout)
         _protocol = getattr(conn, "_protocol")
         timeout = getattr(_protocol, "_get_timeout")(timeout)
 
@@ -190,6 +187,28 @@ class DBAPICursor(base.DBAPICursor):
                 result, self._status = result[:2]
             return result
 
+    async def execute_baked(self, baked_query, timeout, args, one):
+        conn, timeout = await self._acquire(timeout)
+        stmt = conn.baked_queries.get(baked_query)
+        if not stmt:
+            raise RuntimeError("query is not baked yet")
+
+        # work around prepared statement limit per connection acquisition
+        # https://github.com/MagicStack/asyncpg/issues/190
+        stmt._con_release_ctr = conn._pool_release_ctr
+
+        if one:
+            rv = await stmt.fetchrow(*args, timeout=timeout)
+            if rv is None:
+                rv = []
+            else:
+                rv = [rv]
+        else:
+            rv = await stmt.fetch(*args, timeout=timeout)
+        self._attributes = stmt.get_attributes()
+        self._status = stmt.get_statusmsg()
+        return rv
+
     @property
     def description(self):
         return [((a[0], a[1][0]) + (None,) * 5) for a in self._attributes]
@@ -199,14 +218,25 @@ class DBAPICursor(base.DBAPICursor):
 
 
 class Pool(base.Pool):
-    def __init__(self, url, loop, **kwargs):
+    def __init__(self, url, loop, bakery=None, **kwargs):
         self._url = url
         self._loop = loop
         self._kwargs = kwargs
         self._pool = None
+        self._bakery = bakery
+        self._init_hook = None
 
     async def _init(self):
         args = self._kwargs.copy()
+        self._init_hook = args.pop("init", None)
+
+        class Connection(args.pop("connection_class", asyncpg.Connection)):
+            __slots__ = ("baked_queries",)
+
+            def __init__(self, *pargs, **kwargs):
+                super().__init__(*pargs, **kwargs)
+                self.baked_queries = {}
+
         args.update(
             loop=self._loop,
             host=self._url.host,
@@ -214,12 +244,21 @@ class Pool(base.Pool):
             user=self._url.username,
             database=self._url.database,
             password=self._url.password,
+            init=self._bake,
+            connection_class=Connection,
         )
         self._pool = await asyncpg.create_pool(**args)
         return self
 
     def __await__(self):
         return self._init().__await__()
+
+    async def _bake(self, conn):
+        if self._bakery:
+            for bq in self._bakery:
+                conn.baked_queries[bq] = await conn.prepare(bq.sql)
+        if self._init_hook:
+            await self._init_hook(conn)
 
     @property
     def raw_pool(self):
@@ -453,16 +492,22 @@ class AsyncpgDialect(PGDialect, base.AsyncDialectMixin):
 
     def __init__(self, *args, **kwargs):
         self._pool_kwargs = {}
+        self._init_hook = None
         for k in self.init_kwargs:
             if k in kwargs:
-                self._pool_kwargs[k] = kwargs.pop(k)
+                if k == "init":
+                    self._init_hook = kwargs.pop(k)
+                else:
+                    self._pool_kwargs[k] = kwargs.pop(k)
         super().__init__(*args, **kwargs)
         self._init_mixin()
 
     async def init_pool(self, url, loop, pool_class=None):
         if pool_class is None:
             pool_class = Pool
-        return await pool_class(url, loop, init=self.on_connect(), **self._pool_kwargs)
+        return await pool_class(
+            url, loop, bakery=self._bakery, init=self.on_connect(), **self._pool_kwargs
+        )
 
     # noinspection PyMethodMayBeStatic
     def transaction(self, raw_conn, args, kwargs):
@@ -473,10 +518,12 @@ class AsyncpgDialect(PGDialect, base.AsyncDialectMixin):
 
             async def connect(conn):
                 await self.set_isolation_level(conn, self.isolation_level)
+                if self._init_hook:
+                    await self._init_hook(conn)
 
             return connect
         else:
-            return None
+            return self._init_hook
 
     async def set_isolation_level(self, connection, level):
         """

--- a/src/gino/dialects/base.py
+++ b/src/gino/dialects/base.py
@@ -257,7 +257,7 @@ class Cursor:
 
 
 class ExecutionContextOverride:
-    baked_query = False
+    baked_query = None
 
     def _compiled_first_opt(self, key, default=DEFAULT):
         rv = DEFAULT

--- a/src/gino/dialects/base.py
+++ b/src/gino/dialects/base.py
@@ -4,7 +4,8 @@ import weakref
 from sqlalchemy import util
 
 # noinspection PyProtectedMember
-from ..engine import _SAConnection, _SAEngine, _DBAPIConnection
+from ..engine import _SAConnection, _SAEngine, _DBAPIConnection, _bypass_no_param
+from ..exceptions import InitializedError
 from ..loader import Loader
 
 DEFAULT = object()
@@ -35,6 +36,9 @@ class DBAPICursor:
         raise NotImplementedError
 
     async def async_execute(self, query, timeout, args, limit=0, many=False):
+        raise NotImplementedError
+
+    async def execute_baked(self, baked_query, timeout, args, one):
         raise NotImplementedError
 
     def get_statusmsg(self):
@@ -211,9 +215,14 @@ class _ResultProxy:
             )
         else:
             args = param_groups[0]
-            rows = await cursor.async_execute(
-                context.statement, context.timeout, args, 1 if one else 0
-            )
+            if context.baked_query:
+                rows = await cursor.execute_baked(
+                    context.baked_query, context.timeout, args, one
+                )
+            else:
+                rows = await cursor.async_execute(
+                    context.statement, context.timeout, args, 1 if one else 0
+                )
             item = context.process_rows(rows, return_model=return_model)
             if one:
                 if item:
@@ -248,6 +257,8 @@ class Cursor:
 
 
 class ExecutionContextOverride:
+    baked_query = False
+
     def _compiled_first_opt(self, key, default=DEFAULT):
         rv = DEFAULT
         opts = getattr(getattr(self, "compiled", None), "execution_options", None)
@@ -386,10 +397,19 @@ class ExecutionContextOverride:
         self.cursor = self.create_cursor()
         return self
 
+    @classmethod
+    def _init_baked_query(cls, dialect, connection, dbapi_connection, bq, parameters):
+        self = cls._init_compiled(
+            dialect, connection, dbapi_connection, bq.compiled_sql, parameters
+        )
+        self.baked_query = bq
+        return self
+
 
 class AsyncDialectMixin:
     cursor_cls = DBAPICursor
     dbapi_class = BaseDBAPI
+    _bakery = None
 
     def _init_mixin(self):
         self._sa_conn = _SAConnection(
@@ -412,3 +432,14 @@ class AsyncDialectMixin:
 
     def transaction(self, raw_conn, args, kwargs):
         raise NotImplementedError
+
+    def set_bakery(self, bakery):
+        if bakery._closed:
+            raise InitializedError("Cannot reuse a closed bakery!")
+        self._bakery = bakery
+        for bq in bakery:
+            conn = self._sa_conn.execution_options(compiled_cache=bq)
+            context = conn.execute(bq.query, _bypass_no_param).context
+            # noinspection PyProtectedMember
+            bq._set_sql(context.statement)
+        bakery._closed = True

--- a/src/gino/exceptions.py
+++ b/src/gino/exceptions.py
@@ -10,6 +10,10 @@ class UninitializedError(GinoException):
     pass
 
 
+class InitializedError(GinoException):
+    pass
+
+
 class UnknownJSONPropertyError(GinoException):
     pass
 

--- a/src/gino/strategies.py
+++ b/src/gino/strategies.py
@@ -51,6 +51,11 @@ class GinoStrategy(EngineStrategy):
         dialect_args["dbapi"] = dbapi
 
         dialect = dialect_cls(**dialect_args)
+
+        bakery = kwargs.pop("bakery", None)
+        if bakery:
+            dialect.set_bakery(bakery)
+
         pool_class = kwargs.pop("pool_class", None)
         pool = await dialect.init_pool(u, loop, pool_class=pool_class)
 

--- a/tests/test_bakery.py
+++ b/tests/test_bakery.py
@@ -1,0 +1,163 @@
+import pytest
+import sqlalchemy
+
+from gino import UninitializedError, create_engine, InitializedError
+from gino.bakery import Bakery, BakedQuery
+from .models import db, User, PG_URL
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        User.query.where(User.id == db.bindparam("uid")),
+        sqlalchemy.text("SELECT * FROM gino_users WHERE id = :uid"),
+        "SELECT * FROM gino_users WHERE id = :uid",
+        lambda: User.query.where(User.id == db.bindparam("uid")),
+        lambda: sqlalchemy.text("SELECT * FROM gino_users WHERE id = :uid"),
+        lambda: "SELECT * FROM gino_users WHERE id = :uid",
+    ],
+)
+@pytest.mark.parametrize("options", [dict(return_model=False), dict(loader=User)])
+@pytest.mark.parametrize("api", [True, False])
+@pytest.mark.parametrize("timeout", [None, 1])
+async def test(query, options, sa_engine, api, timeout):
+    uid = sa_engine.scalar(User.insert().returning(User.id))
+    if timeout:
+        options["timeout"] = timeout
+
+    if api:
+        b = db._bakery
+        qs = [db.bake(query, **options)]
+        if callable(query):
+            qs.append(db.bake(**options)(query))
+    else:
+        b = Bakery()
+        qs = [b.bake(query, **options)]
+        if callable(query):
+            qs.append(b.bake(**options)(query))
+
+    for q in qs:
+        assert isinstance(q, BakedQuery)
+        assert q in list(b)
+        assert q.sql is None
+        assert q.compiled_sql is None
+
+        with pytest.raises(UninitializedError):
+            q.bind.first()
+        with pytest.raises(UninitializedError):
+            await q.first()
+
+        for k, v in options.items():
+            assert q.query.get_execution_options()[k] == v
+
+    if api:
+        e = await db.set_bind(PG_URL, min_size=1)
+    else:
+        e = await create_engine(PG_URL, bakery=b, min_size=1)
+
+    with pytest.raises(InitializedError):
+        b.bake("SELECT now()")
+
+    with pytest.raises(InitializedError):
+        await create_engine(PG_URL, bakery=b, min_size=0)
+
+    try:
+        for q in qs:
+            assert q.sql is not None
+            assert q.compiled_sql is not None
+
+            if api:
+                assert q.bind is e
+            else:
+                with pytest.raises(UninitializedError):
+                    q.bind.first()
+                with pytest.raises(UninitializedError):
+                    await q.first()
+
+            if api:
+                rv = await q.first(uid=uid)
+            else:
+                rv = await e.first(q, uid=uid)
+
+            if options.get("return_model", True):
+                assert isinstance(rv, User)
+                assert rv.id == uid
+            else:
+                assert rv[0] == rv[User.id] == rv["id"] == uid
+
+            eq = q.execution_options(return_model=True, loader=User)
+            assert eq is not q
+            assert isinstance(eq, BakedQuery)
+            assert type(eq) is not BakedQuery
+            assert eq in list(b)
+            assert eq.sql == q.sql
+            assert eq.compiled_sql is not q.compiled_sql
+
+            if api:
+                assert q.bind is e
+            else:
+                with pytest.raises(UninitializedError):
+                    eq.bind.first()
+                with pytest.raises(UninitializedError):
+                    await eq.first()
+
+            assert eq.query.get_execution_options()["return_model"]
+            assert eq.query.get_execution_options()["loader"] is User
+
+            if api:
+                rv = await eq.first(uid=uid)
+                non = await eq.first(uid=uid + 1)
+                rvl = await eq.all(uid=uid)
+            else:
+                rv = await e.first(eq, uid=uid)
+                non = await e.first(eq, uid=uid + 1)
+                rvl = await e.all(eq, uid=uid)
+
+            assert isinstance(rv, User)
+            assert rv.id == uid
+
+            assert non is None
+
+            assert len(rvl) == 1
+            assert rvl[0].id == uid
+
+            # original query is not affected
+            if api:
+                rv = await q.first(uid=uid)
+            else:
+                rv = await e.first(q, uid=uid)
+
+            if options.get("return_model", True):
+                assert isinstance(rv, User)
+                assert rv.id == uid
+            else:
+                assert rv[0] == rv[User.id] == rv["id"] == uid
+
+    finally:
+        if api:
+            await db.pop_bind().close()
+        else:
+            await e.close()
+
+
+async def test_init_hooks():
+    b = Bakery()
+    q = b.bake("SELECT 123")
+    hooked_conn = None
+
+    async def init(con):
+        nonlocal hooked_conn
+        hooked_conn = con
+
+    e = await create_engine(
+        PG_URL, bakery=b, isolation_level="READ_UNCOMMITTED", init=init, min_size=0
+    )
+    async with e.acquire() as conn:
+        assert (
+            await e.dialect.get_isolation_level(conn.raw_connection)
+            == "READ UNCOMMITTED"
+        )
+        assert await conn.scalar(q) == 123
+        assert hooked_conn is conn.raw_connection._con

--- a/tests/test_declarative.py
+++ b/tests/test_declarative.py
@@ -306,3 +306,25 @@ async def test_multiple_inheritance_overwrite_declared_table_name():
 
     assert MyTableWithoutName.__table__.name == "static_table_name"
     assert MyOtherTableWithoutName.__table__.name == "myothertablewithoutname"
+
+
+async def test_declared_attr_with_table():
+    n_call = 0
+
+    class Model(db.Model):
+        @db.declared_attr()
+        def __tablename__(cls):
+            return "model6"
+
+        @db.declared_attr(with_table=True)
+        def table_name(cls):
+            nonlocal n_call
+            n_call += 1
+            return cls.__table__.name
+
+    assert Model.__table__.name == "model6"
+    assert n_call == 1
+    assert Model.table_name == "model6"
+    assert n_call == 1
+    assert Model.table_name == "model6"
+    assert n_call == 1


### PR DESCRIPTION
* Fixes #478
* Refs #631: Query performance boost: >40%

This adds ``Bakery`` and ``db.bake()`` that will pre-compile SQLAlchemy query clause instances and create ``PreparedStatement`` for every baked query per DB connection in the pool.

```python
db = gino.Gino()
user_query = db.bake(User.query.where(User.id == db.bindparam("id"))

async def user_info(request):
    user = await user_query.first(id=request.args.get("user_id"))
```