### PR TITLE
Fix model override behavior

### DIFF
--- a/src/gino/declarative.py
+++ b/src/gino/declarative.py
@@ -289,8 +289,12 @@ class Model:
         inspected_args = []
         updates = {}
         column_name_map = InvertDict()
-        for each_cls in sub_cls.__mro__[::-1]:
+        visited = set()
+        for each_cls in sub_cls.__mro__:
             for k, v in getattr(each_cls, "__namespace__", each_cls.__dict__).items():
+                if k in visited:
+                    continue
+                visited.add(k)
                 declared_callable_attr = callable(v) and getattr(
                     v, "__declared_attr__", False
                 )

--- a/tests/test_declarative.py
+++ b/tests/test_declarative.py
@@ -328,3 +328,20 @@ async def test_declared_attr_with_table():
     assert n_call == 1
     assert Model.table_name == "model6"
     assert n_call == 1
+
+
+async def test_override():
+    class ModelMixin:
+        field = db.Column(db.String)
+
+    class Model(db.Model, ModelMixin):
+        __tablename__ = "model7"
+
+        normal = db.Column(db.Integer)
+
+        @property
+        def field(self):
+            return "field is a const value"
+
+    assert len(Model.__table__.columns) == 1
+    assert Model().field == "field is a const value"


### PR DESCRIPTION
Please refer to the new test case: we should always stick with the leaf-most attributes in an MRO list, regardless of their former types.