### PR TITLE
Fix JSON props issue in mixin classes

### DIFF
--- a/src/gino/declarative.py
+++ b/src/gino/declarative.py
@@ -315,6 +315,8 @@ class Model:
                     updates[k] = sub_cls.__attr_factory__(k, v)
                 elif isinstance(v, (sa.Index, sa.Constraint)):
                     inspected_args.append(v)
+                elif isinstance(v, json_support.JSONProperty):
+                    updates[k] = v
         if table_name is None:
             return
         sub_cls._column_name_map = column_name_map
@@ -351,6 +353,8 @@ class Model:
         for each_cls in sub_cls.__mro__[::-1]:
             for k, v in each_cls.__dict__.items():
                 if isinstance(v, json_support.JSONProperty):
+                    if not v.name:
+                        v.name = k
                     json_col = getattr(
                         sub_cls.__dict__.get(v.prop_name), "column", None
                     )


### PR DESCRIPTION
The first change is to make sure `CRUDModel.update` could get the right value:

https://github.com/python-gino/gino/blob/65aed1308eca57a3a787728442dce6b1ad8fe7f8/src/gino/crud.py#L212-L214

And the second change is to set the name correctly on mixin classes that don't have this:

https://github.com/python-gino/gino/blob/65aed1308eca57a3a787728442dce6b1ad8fe7f8/src/gino/declarative.py#L76-L82