### PR TITLE
Add ability to use Column type with CRUDModel select method

### DIFF
--- a/src/gino/crud.py
+++ b/src/gino/crud.py
@@ -36,7 +36,9 @@ class _Query:
 class _Select:
     def __get__(self, instance, owner):
         def select(*args):
-            q = sa.select([getattr(owner, x) for x in args])
+            q = sa.select(
+                [getattr(owner, x) if isinstance(x, str) else x for x in args]
+            )
             if instance is not None:
                 q = q.where(instance.lookup())
             return q.execution_options(model=weakref.ref(owner), return_model=False)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -100,7 +100,13 @@ async def test_select(engine):
     name = await engine.scalar(User.select("nickname").where(User.id == u.id))
     assert u.nickname == name
 
+    name = await engine.scalar(User.select(User.nickname).where(User.id == u.id))
+    assert u.nickname == name
+
     name = await engine.scalar(u.select("nickname"))
+    assert u.nickname == name
+
+    name = await engine.scalar(u.select(User.nickname))
     assert u.nickname == name
 
 


### PR DESCRIPTION
GINO is awesome, thanks guys 😊

Regarding this PR.
We can use `Column` type with SQLAlchemy select:
```python
await db.select([User.nickname]).gino.all()
```

Purpose of this PR is to add similar functionality to `CRUDModel` `select` method:
```python
await User.select(User.nickname).gino.all()
```
