### PR TITLE
compatibility fix for event callback

### DIFF
--- a/src/gino/schema.py
+++ b/src/gino/schema.py
@@ -399,7 +399,9 @@ class AsyncSchemaTypeMixin:
 
 
 async def _call_portable_instancemethod(fn, args, kw):
-    m = getattr(fn.target, fn.name + "_async", None)
+    m = None
+    if hasattr(fn, "target"):
+        m = getattr(fn.target, fn.name + "_async", None)
     if m is None:
         return fn(*args, **kw)
     else:


### PR DESCRIPTION
for callbacks without sqlalchemy.util.portable_instancemethod wrapper

refs #691 