### PR TITLE
Use asyncpg dsn

### DIFF
--- a/src/gino/dialects/asyncpg.py
+++ b/src/gino/dialects/asyncpg.py
@@ -245,14 +245,9 @@ class Pool(base.Pool):
                 self.baked_queries = {}
 
         args.update(
-            loop=self._loop,
-            host=self._url.host,
-            port=self._url.port,
-            user=self._url.username,
-            database=self._url.database,
-            password=self._url.password,
-            connection_class=Connection,
+            connection_class=Connection, dsn=str(self._url), loop=self._loop,
         )
+
         if self._prebake and self._bakery:
             self._init_hook = args.pop("init", None)
             args["init"] = self._bake

--- a/src/gino/strategies.py
+++ b/src/gino/strategies.py
@@ -1,11 +1,12 @@
 import asyncio
 from copy import copy
 
-from sqlalchemy.engine import url
 from sqlalchemy import util
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.engine.strategies import EngineStrategy
 
 from .engine import GinoEngine
+from .dialects.asyncpg import AsyncpgDialect
 
 
 class GinoStrategy(EngineStrategy):
@@ -14,8 +15,7 @@ class GinoStrategy(EngineStrategy):
     This strategy is initialized automatically as :mod:`gino` is imported.
 
     If :func:`sqlalchemy.create_engine` uses ``strategy="gino"``, it will return a
-    :class:`~collections.abc.Coroutine`, and treat URL prefix ``postgresql://`` or
-    ``postgres://`` as ``postgresql+asyncpg://``.
+    :class:`~collections.abc.Coroutine`.
     """
 
     name = "gino"
@@ -23,14 +23,16 @@ class GinoStrategy(EngineStrategy):
 
     async def create(self, name_or_url, loop=None, **kwargs):
         engine_cls = self.engine_cls
-        u = url.make_url(name_or_url)
+        url = make_url(name_or_url)
         if loop is None:
             loop = asyncio.get_event_loop()
-        if u.drivername in {"postgresql", "postgres"}:
-            u = copy(u)
-            u.drivername = "postgresql+asyncpg"
 
-        dialect_cls = u.get_dialect()
+        # The postgresql dialect is already taken by the PGDialect_psycopg2
+        # we need to force ourone.
+        if url.drivername in ("postgresql", "postgres"):
+            dialect_cls = AsyncpgDialect
+        else:
+            dialect_cls = url.get_dialect()
 
         pop_kwarg = kwargs.pop
 
@@ -52,7 +54,7 @@ class GinoStrategy(EngineStrategy):
 
         dialect = dialect_cls(**dialect_args)
         pool_class = kwargs.pop("pool_class", None)
-        pool = await dialect.init_pool(u, loop, pool_class=pool_class)
+        pool = await dialect.init_pool(url, loop, pool_class=pool_class)
 
         engine_args = dict(loop=loop)
         for k in util.get_cls_kwargs(engine_cls):


### PR DESCRIPTION
Currently Gino is overriding a asyncpg connection host, port, user, password, database settings before passing them to the [connection pool](https://github.com/python-gino/gino/blob/master/src/gino/dialects/asyncpg.py#L247).

Because of this behavior developers are not able to pass host, port arguments as a query string.
The [asyncpg documentation](https://magicstack.github.io/asyncpg/current/api/index.html#connection) is explaining that in more details.

In other words url like:
`postgresql://postgres@postgres/mydb?host=/cloudsql/project:us-central1:bd/.s.PGSQL.5432` will use `localhost` value instead of socket path. This is how a DSN looks like when you work with Google Cloud SQL server. Unfortunately [Google examples](https://codelabs.developers.google.com/codelabs/connecting-to-cloud-sql-with-cloud-functions/#2) doesn't work with Gino.


