### PR TITLE
Add naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,12 @@ docs/_build/
 # PyBuilder
 target/
 
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+
 # pyenv python configuration file
 .python-version
 
@@ -73,3 +79,6 @@ target/
 
 # extension stub files
 src/gino/ext/*.pyi
+
+# virtual env
+venv/

--- a/src/gino/api.py
+++ b/src/gino/api.py
@@ -210,6 +210,15 @@ class _BindContext:
         await self._args[0].pop_bind().close()
 
 
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s"
+}
+
+
 class Gino(sa.MetaData):
     """
     All-in-one API class of GINO, providing several shortcuts.
@@ -355,7 +364,7 @@ class Gino(sa.MetaData):
                        :class:`~sqlalchemy.schema.MetaData`.
 
         """
-        super().__init__(bind=bind, **kwargs)
+        super().__init__(bind=bind, naming_convention=NAMING_CONVENTION, **kwargs)
         if model_classes is None:
             model_classes = self.model_base_classes
         self._model = declarative_base(self, model_classes)

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,12 +2,15 @@ import os
 import enum
 import random
 import string
+import uuid
 from datetime import datetime
 
 import pytest
 
 from gino import Gino
 from gino.dialects.asyncpg import JSONB
+from sqlalchemy.dialects.postgresql import UUID
+
 
 DB_ARGS = dict(
     host=os.getenv("DB_HOST", "localhost"),
@@ -134,7 +137,7 @@ class CompanyWithoutTeamsSetter(Company):
 class UserSetting(db.Model):
     __tablename__ = "gino_user_settings"
 
-    # No constraints defined on columns
+    # No constraints defined on these columns
     id = db.Column(db.BigInteger())
     user_id = db.Column(db.BigInteger())
     setting = db.Column(db.Text())
@@ -142,11 +145,15 @@ class UserSetting(db.Model):
     col1 = db.Column(db.Integer, default=1)
     col2 = db.Column(db.Integer, default=2)
 
+    # Some constraints defined on these columns
+    col3 = db.Column(UUID, default=uuid.uuid4, unique=True)
+    col4 = db.Column(db.Integer, default=4, nullable=False)
+
     # Define indexes and constraints inline
     id_pkey = db.PrimaryKeyConstraint("id")
     user_id_fk = db.ForeignKeyConstraint(["user_id"], ["gino_users.id"])
     user_id_setting_unique = db.UniqueConstraint("user_id", "setting")
-    col1_check = db.CheckConstraint("col1 >= 1 AND col1 <= 5")
+    col1_check = db.CheckConstraint("col1 >= 1 AND col1 <= 5", "check_col1")
     col2_idx = db.Index("col2_idx", "col2")
 
 


### PR DESCRIPTION
Rationale:

This is basically a poka-yoke design, for

1. Disabling constraints without names
2. Generating constraints with names in alembic migrations
  - Alembic will not generate names for constraints defined in columns, like `unique=True`
  - Alembic will complain when it's downgrading a constraint without name

FYI:
https://alembic.sqlalchemy.org/en/latest/naming.html
