### PR TITLE
Set default level of logger "gino" to WARNING

### DIFF
--- a/src/gino/__init__.py
+++ b/src/gino/__init__.py
@@ -1,8 +1,14 @@
+import logging
+
 from .api import Gino  # NOQA
 from .bakery import Bakery
 from .engine import GinoEngine, GinoConnection  # NOQA
 from .exceptions import *  # NOQA
 from .strategies import GinoStrategy  # NOQA
+
+rootlogger = logging.getLogger("gino")
+if rootlogger.level == logging.NOTSET:
+    rootlogger.setLevel(logging.WARN)
 
 
 def create_engine(*args, **kwargs):


### PR DESCRIPTION
Looks like the `echo=False` feature depends on that the default level of a parent logger of `gino.engine._SAEngine` is `WARNING`. Without this fix, the parent logger is `root`. In cases of for example uvicorn, the default root level is `INFO` and `echo=False` didn't work.

Fixes #710