### PR TITLE
fix #717, return empty objects instead of None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ GINO 1.1
 * Added baked query feature (#478 #659 #667)
 * Added ``Query.gino.execution_options`` shortcut (#659)
 * Added ``@db.declared_attr(with_table=True)`` (#659)
+* [Breaking] empty object instead of ``None`` being returned for objects with values of all selected columns are None (#729)
 
 
 GINO 1.0

--- a/mysql_tests/test_loader.py
+++ b/mysql_tests/test_loader.py
@@ -370,7 +370,7 @@ async def test_tuple_loader_279(user):
 async def test_none_as_none_281(user):
     query = Team.outerjoin(User).select()
     loader = Team, User
-    assert any(row[1] is None for row in await query.gino.load(loader).all())
+    assert any(row[1].id is None for row in await query.gino.load(loader).all())
 
     loader = Team.distinct(Team.id).load(add_member=User)
     assert any(not team.members for team in await query.gino.load(loader).all())

--- a/src/gino/loader.py
+++ b/src/gino/loader.py
@@ -123,6 +123,7 @@ class Loader:
 
 
 _none = object()
+_none_as_none = object()
 
 
 def _get_column(model, column_or_name) -> Column:
@@ -213,6 +214,8 @@ class ModelLoader(Loader):
         self.on_clause = None
 
     def _do_load(self, row, none_as_none):
+        # none_as_none indicates that in the case of every column of the object is
+        # None, whether a None or empty instance of the model should be returned.
         values = dict((c.name, row[c]) for c in self.columns if c in row)
         if none_as_none and all((v is None) for v in values.values()):
             return None
@@ -233,27 +236,29 @@ class ModelLoader(Loader):
                  result is distinct.
         """
 
+        if context is None:
+            context = {}
         distinct = True
         if self._distinct:
-            if context is None:
-                context = {}
             ctx = context.setdefault(self._distinct, {})
             key = tuple(row[col] for col in self._distinct)
             rv = ctx.get(key, _none)
             if rv is _none:
-                rv = self._do_load(row, context.get('none_as_none', False))
+                rv = self._do_load(row, context.get(_none_as_none, False))
                 ctx[key] = rv
             else:
                 distinct = False
         else:
-            rv = self._do_load(row, context.get('none_as_none', False))
+            rv = self._do_load(row, context.get(_none_as_none, False))
 
         if rv is None:
             return None, None
         else:
             for key, value in self.extras.items():
-                context.setdefault('none_as_none', True)
+                context.setdefault(_none_as_none, True)
                 value, distinct_ = value.do_load(row, context)
+                # _none_as_none should not be propagated to parents
+                context.pop(_none_as_none, 0)
                 if distinct_ is None:
                     continue
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -370,7 +370,7 @@ async def test_tuple_loader_279(user):
 async def test_none_as_none_281(user):
     query = Team.outerjoin(User).select()
     loader = Team, User
-    assert any(row[1] is None for row in await query.gino.load(loader).all())
+    assert any(row[1].id is None for row in await query.gino.load(loader).all())
 
     loader = Team.distinct(Team.id).load(add_member=User)
     assert any(not team.members for team in await query.gino.load(loader).all())


### PR DESCRIPTION
For queries that request for selected columns and all the returned
results are NULL, still construct the objects with all values None.

This contradicts #281 and #282 to some extent.
It makes sense to set None of a related model as an attribute of the main object, like user.team is None.
In the case of the main object, I think it also makes sense to return an object instead of None when I queries it.

If this makes sense to all of you, I'll continue with the documentation parts.
