### PR TITLE
fix typo in bakery docs

### DIFF
--- a/docs/how-to/bakery.rst
+++ b/docs/how-to/bakery.rst
@@ -71,7 +71,7 @@ Pass in parameter values::
 Use the :class:`~gino.api.Gino` Integration
 --------------------------------------------
 
-In a more common scenario, there will be a :class:`~gino.api.Gino>` instance, which has
+In a more common scenario, there will be a :class:`~gino.api.Gino` instance, which has
 usually a ``bind`` set - either explicitly or by the Web framework extensions::
 
     from gino import Gino


### PR DESCRIPTION
Just a small typo found while browsing the [docs](https://python-gino.org/docs/en/master/how-to/bakery.html#use-the-gino-integration)

(edit: Noticed the failing checks, but I'm pretty confident this commit shouldn't cause them!)