### PR TITLE
a way to retreive all public tables

### DIFF
--- a/src/gino/dialects/aiomysql.py
+++ b/src/gino/dialects/aiomysql.py
@@ -492,6 +492,19 @@ class AiomysqlDialect(MySQLDialect, base.AsyncDialectMixin):
             exception = exception.args[0]
         return exception.args[0]
 
+    async def get_table_name(self, connection):
+        TABLE_SQL = text("""
+        SELECT table_schema AS database_name,
+            table_name
+        FROM information_schema.tables
+        WHERE table_type = 'BASE TABLE'
+            AND table_schema NOT IN ('information_schema','mysql',
+                                     'performance_schema','sys')
+        ORDER BY database_name, table_name;
+                """)
+
+        return await connection.all(TABLE_SQL)
+
 
 def _escape_args(args, conn):
     if isinstance(args, (tuple, list)):

--- a/src/gino/dialects/asyncpg.py
+++ b/src/gino/dialects/asyncpg.py
@@ -690,3 +690,12 @@ class AsyncpgDialect(PGDialect, base.AsyncDialectMixin):
                 ),
             )
         return bool(await connection.scalar(query))
+
+    async def get_table_names(self, connection):
+        TABLE_SQL = sql.text("""
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+        """)
+
+        return await connection.all(TABLE_SQL)

--- a/src/gino/dialects/base.py
+++ b/src/gino/dialects/base.py
@@ -166,7 +166,7 @@ class _IterableCursor:
         return self._context.cursor.iterate(self._context)
 
     async def _get_cursor(self):
-        return await (await self._iterate())
+        return await(await self._iterate())
 
     def __aiter__(self):
         return _LazyIterator(self._iterate)


### PR DESCRIPTION
A way to retrieve all the public tables in databases #751 by creating a _get_tables_ function in both the _Postgres_ and _MySQL_ dialect. In the absence of the reflection and inspection abstraction of sqlalchemy in gino, this is the least possible way of retrieving some form of metadata from the database without having to write personalized SQL queries in your project. It works the same as any function in the dialect module of the gino connection or engine.

```python
conn = await engine.acquire()
return await engine.dialect.get_table_names(conn)
```