### PR TITLE
remove python 3.5 from CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     services:
       postgres:
         image: fantix/postgres-ssl:13.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     steps:
       - name: source code
         uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6', '3.7', '3.8' ]
+        python-version: [ '3.6', '3.7', '3.8' ]
     services:
       postgres:
         image: fantix/postgres-ssl:13.1


### PR DESCRIPTION
Due to python 3.5 reaching [EOL](https://www.python.org/downloads/release/python-3510/) it should be able to be removed from CI. Related source issue #731 