### PR TITLE
Optimize columns loading: lazy create row locator

### DIFF
--- a/src/gino/crud.py
+++ b/src/gino/crud.py
@@ -435,7 +435,8 @@ class CRUDModel(Model):
     def __init__(self, **values):
         super().__init__()
         self.__profile__ = None
-        self._update_request_cls(self).update(**values)
+        if values:
+            self._update_request_cls(self).update(**values)
 
     @classmethod
     def _init_table(cls, sub_cls):


### PR DESCRIPTION
Locator instance builds unnecessary query for each row when the model is loaded from a database, to my mind, it is better to create an instance of the locator/UpdateRequest lazily (only if some values are passed to the model)

Here are the results of the benchmarks for loading 20000 rows, from my previous PR

https://github.com/python-gino/gino/pull/786#issuecomment-865472758

## before
```
CPU time: 0.55 s, Real time: 0.56 s

Single column loader
CPU time: 0.33 s, Real time: 0.33 s

Partial loader
CPU time: 0.45 s, Real time: 0.45 s
```

## after
```
CPU time: 0.20 s, Real time: 0.20 s
Single column loader
CPU time: 0.04 s, Real time: 0.04 s
Partial loader
CPU time: 0.15 s, Real time: 0.15 s
```
